### PR TITLE
Support for move command

### DIFF
--- a/args-json/args-move_policy.json
+++ b/args-json/args-move_policy.json
@@ -1,0 +1,16 @@
+{
+        "ANSIBLE_MODULE_ARGS": {
+            "action": "move",
+            "config": "firewall policy",
+            "https": "False",
+            "config_parameters": {
+                   "key": "1",
+                   "where": "before",
+                   "reference-key": "2"
+            },
+            "host": "192.168.122.40",
+            "password": "",
+            "username": "admin",
+            "vdom": "global"
+        }
+}


### PR DESCRIPTION
This intends to allow to move policies and other objects in FortiGate configuration to set different priorities. It translates the playbook to REST API's 'move' call.