### PR TITLE
fixes missing documentation error on ansible 2.7.10

### DIFF
--- a/library/fortiosconfig.py
+++ b/library/fortiosconfig.py
@@ -32,8 +32,9 @@ import re
 DOCUMENTATION = '''
 ---
 module: fortiosconfig
-short_description: Module to configure all aspects of \
-fortinet products using the REST API
+short_description: Configure FortiOS using the REST API
+description:
+    - Module to configure all aspects of FortiOS using the REST API
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
Current module causes a error when checked with ansible-doc.

```
loki:library draks$ ansible-doc -t module fortiosconfig
ERROR! module fortiosconfig missing documentation (or could not parse documentation): 'description'
```

This PR fixes that error.

```
loki:library draks$ ansible-doc -t module fortiosconfig

> FORTIOSCONFIG    (/Users/draks/Documents/github/fork/40ansible/library/fortiosconfig.py)

        Module to configure all aspects of FortiOS using the REST API


EXAMPLES:

- hosts: localhost
  strategy: debug
  vars:
   host: "192.168.40.8"
   username: "admin"
   password: ""
   vdom: "root"
  tasks:
  - name: Set static route on the fortigate
    fortiosconfig:
     action: "set"
     host:  "{{  host }}"
     username: "{{  username}}"
     password: "{{ password }}"
     vdom:  "{{  vdom }}"
     config: "router static"
     config_parameters:
       seq-num: "8"
       dst: "10.10.32.0 255.255.255.0"
       device: "port2"
       gateway: "192.168.40.252"
  - name: Delete firewall address
    fortiosconfig:
     config: "firewall address"
     action: "delete"
     host:  "{{ host }}"
     username: "{{ username }}"
     password: "{{ password }}"
     vdom:  "{{  vdom }}"
     config_parameters:
       wildcard-fqdn: "*.test.ansible.com"
       name: "test-ansible"
       type: "wildcard-fqdn"
  - name: Move policies
    fortiosconfig: 
     config: "firewall policy"
     action: "move"
     host:  "{{ host }}"
     username: "{{ username }}"
     password: "{{ password }}"
     vdom:  "{{  vdom }}"
     config_parameters:
       key: 1
       where: "before"
       reference-key: 2
```