### PR TITLE
Monitor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+.idea

--- a/args-json/args-vpn_certificate_generate_csr.json
+++ b/args-json/args-vpn_certificate_generate_csr.json
@@ -1,0 +1,23 @@
+{
+        "ANSIBLE_MODULE_ARGS": {
+            "action": "post",
+            "config": "vpn-certificate csr generate",
+            "https": "True",
+            "config_parameters": {
+               "certname": "mycert",
+               "keytype": "rsa",
+               "keysize": 4096,
+               "subject": "sub2",
+               "org": "Fortinet",
+               "city": "Sunnyvale",
+               "state": "California",
+               "countrycode": "US",
+               "email": "admin@fortinet.com",
+               "sub_alt_name": "sub_alt"
+            },
+            "host": "192.168.122.40",
+            "password": "",
+            "username": "admin",
+            "vdom": "global"
+        }
+}

--- a/examples/fortigate_mix.yml
+++ b/examples/fortigate_mix.yml
@@ -75,9 +75,9 @@
         fmg: "10.210.67.18"
   - name: system resource
     fortiosconfig:
-     config: "system vdom-resource"
-     action: "monitor"
-     host:  "{{ host }}"  
+     config: "system vdom-resource select"
+     action: "get"
+     host:  "{{ host }}"
      username: "{{ username }}"  
      password: "{{ password }}"
      vdom: "global"

--- a/examples/fortigate_monitor_system_resource_usage.yml
+++ b/examples/fortigate_monitor_system_resource_usage.yml
@@ -9,7 +9,7 @@
     - name: Get system resource usage
       fortiosconfig:
        config: "system resource usage"
-       action: "monitor"
+       action: "get"
        host:  "{{ host }}"
        username: "{{ username }}"
        password: "{{ password }}"

--- a/examples/fortigate_vpn_certificate_csr_delete.yml
+++ b/examples/fortigate_vpn_certificate_csr_delete.yml
@@ -1,0 +1,18 @@
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "global"
+  tasks:
+  - name: Generate vpn certificate
+    fortiosconfig:
+     config: "vpn.certificate local"
+     action: "delete"
+     host:  "{{ host }}"
+     username: "{{ username }}"
+     password: "{{ password }}"
+     vdom:  "{{ vdom }}"
+     https: True
+     config_parameters:
+       name: "mycert"

--- a/examples/fortigate_vpn_certificate_csr_generate.yml
+++ b/examples/fortigate_vpn_certificate_csr_generate.yml
@@ -1,0 +1,27 @@
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "global"
+  tasks:
+  - name: Generate vpn certificate
+    fortiosconfig:
+     config: "vpn-certificate csr generate"
+     action: "post"
+     host:  "{{ host }}"
+     username: "{{ username }}"
+     password: "{{ password }}"
+     vdom:  "{{ vdom }}"
+     https: True
+     config_parameters:
+       certname: "mycert"
+       keytype: "rsa"
+       keysize: 4096
+       subject: "sub2"
+       org: "Fortinet"
+       city: "Sunnyvale"
+       state: "California"
+       countrycode: "US"
+       email: "admin@fortinet.com"
+       sub_alt_name: "sub_alt"

--- a/library/fortiosconfig.py
+++ b/library/fortiosconfig.py
@@ -525,15 +525,15 @@ def fortigate_put(data):
 def fortigate_post(data):
     resource = data['config']
     if resource in CONFIG_CALLS:
-        return fortigate_config_post(data)
+        return _fortigate_config_post(data)
     elif resource in MONITOR_CALLS:
-        return fortigate_monitor_post(data)
+        return _fortigate_monitor_post(data)
     else:
         return True, False, {'status': 'Error: Resource does not belong to config or monitor',
                              'http_status': '500'}
 
 
-def fortigate_config_post(data):
+def _fortigate_config_post(data):
     login(data)
 
     functions = data['config'].split()
@@ -549,12 +549,12 @@ def fortigate_config_post(data):
         return True, False, meta
 
 
-def fortigate_monitor_post(data):
+def _fortigate_monitor_post(data):
     login(data)
 
     functions = data['config'].split()
 
-    resp = fos.monitor_post(functions[0], functions[1] + '/' + functions[2], vdom=data['vdom'],
+    resp = fos.exec(functions[0], functions[1] + '/' + functions[2], vdom=data['vdom'],
                     data=data['config_parameters'])
     logout()
 
@@ -586,15 +586,15 @@ def fortigate_set(data):
 def fortigate_get(data):
     resource = data['config']
     if resource in CONFIG_CALLS:
-        return fortigate_config_get(data)
+        return _fortigate_config_get(data)
     elif resource in MONITOR_CALLS:
-        return fortigate_monitor_get(data)
+        return _fortigate_monitor_get(data)
     else:
         return True, False, {'status': 'Error: Resource does not belong to config or monitor',
                              'http_status': '500'}
 
 
-def fortigate_config_get(data):
+def _fortigate_config_get(data):
     login(data)
 
     functions = data['config'].split()
@@ -621,14 +621,14 @@ def fortigate_config_get(data):
         }
 
 
-def fortigate_monitor_get(data):
+def _fortigate_monitor_get(data):
     login(data)
 
     functions = data['config'].split()
 
     path, name = extract_path_and_name(functions)
 
-    resp = fos.monitor_get(path, name, vdom=data['vdom'])
+    resp = fos.monitor(path, name, vdom=data['vdom'])
     logout()
 
     if resp['status'] == "success":
@@ -721,7 +721,7 @@ def check_diff(data):
     parameters = {'destination': 'file',
                   'scope': 'global'}
 
-    resp = fos.monitor_get('system/config',
+    resp = fos.monitor('system/config',
                        'backup',
                        vdom=data['vdom'],
                        parameters=parameters)
@@ -776,7 +776,7 @@ def fortigate_backup(data):
     parameters = {'destination': 'file',
                   'scope': 'global'}
 
-    resp = fos.monitor_get(functions[0] + '/' + functions[1],
+    resp = fos.monitor(functions[0] + '/' + functions[1],
                        functions[2],
                        vdom=data['vdom'],
                        parameters=parameters)
@@ -912,7 +912,7 @@ def main():
         "put": fortigate_put,
         "post": fortigate_post,
         "get": fortigate_get,
-        "monitor": fortigate_monitor_get,  # deprecated
+        "monitor": _fortigate_monitor_get,  # deprecated
         "ssh": fortigate_ssh,
         "backup": fortigate_backup,
         "restore": fortigate_upload,

--- a/library/fortiosconfig.py
+++ b/library/fortiosconfig.py
@@ -554,7 +554,7 @@ def _fortigate_monitor_post(data):
 
     functions = data['config'].split()
 
-    resp = fos.exec(functions[0], functions[1] + '/' + functions[2], vdom=data['vdom'],
+    resp = fos.execute(functions[0], functions[1] + '/' + functions[2], vdom=data['vdom'],
                     data=data['config_parameters'])
     logout()
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -109,6 +109,9 @@ wait_until_fgt_validates_license
 run_example fortigate_disable_https_redirect.yml
 run_example fortigate_create_firewall_policy.yml
 run_example fortigate_delete_firewall_policy.yml
+# Uncomment after 6.2.1 release, when vpn certificate is fixed in REST API
+#run_example fortigate_vpn_certificate_csr_generate.yml
+#run_example fortigate_vpn_certificate_csr_delete.yml
 
 remove_waste_files
 


### PR DESCRIPTION
Basic support for Monitor API calls.

Despite Monitor API is not well suited for Ansible, due to its own nature, basically operational status, and one-shot operations, some operations have been included here to help specific cases and scenarios.

For now a basic set of operations is included, supporting get and post operations in the API. More operations can be included afterwards.

Please note that in some cases it is not possible to respect idempotency in Monitor calls.