### PR TITLE
Restore Each VDOM

### DIFF
--- a/library/fortiosconfig.py
+++ b/library/fortiosconfig.py
@@ -830,7 +830,7 @@ def fortigate_backup(data):
         'backup': backup_content
     }
 
-
+# Make sure the specific VDOM exists in the fortigate. Using fortios_system_vdom module to creat a VDOM before restoring it.
 def fortigate_upload(data):
     login(data)
 

--- a/library/fortiosconfig.py
+++ b/library/fortiosconfig.py
@@ -830,7 +830,7 @@ def fortigate_backup(data):
         'backup': backup_content
     }
 
-# Make sure the specific VDOM exists in the fortigate. Using fortios_system_vdom module to creat a VDOM before restoring it.
+# Make sure the specific VDOM exists in the fortigate before restoring it. Using fortios_system_vdom module to create a VDOM.
 def fortigate_upload(data):
     login(data)
 


### PR DESCRIPTION
Add restore_each_VDOM feature to let the users restore a specific VDOM. 

Make sure the specific VDOM exists in the fortigate before restoring it. Using fortios_system_vdom module to create a VDOM. 

1. Create a VDOM

<img width="193" alt="create_vdom_v4" src="https://user-images.githubusercontent.com/59745792/74578262-72c56480-4f48-11ea-956d-c324d511846e.PNG">

2. Restore a specific VDOM
<img width="182" alt="restore_v3_playbook" src="https://user-images.githubusercontent.com/59745792/74578293-a4d6c680-4f48-11ea-830e-4f1b91049941.PNG">

3. Execution results
<img width="655" alt="restore_v3_results" src="https://user-images.githubusercontent.com/59745792/74578337-ef584300-4f48-11ea-8696-bc63738d1f01.PNG">
